### PR TITLE
confine pre-commit to stages

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,6 +1,7 @@
 -   id: isort
     name: isort
     entry: isort
+    stages: [commit, merge-commit, push, manual]
     require_serial: true
     language: python
     types_or: [cython, pyi, python]


### PR DESCRIPTION
See https://pre-commit.com/#confining-hooks-to-run-at-certain-stages

> If you are authoring a tool, it is usually a good idea to provide an appropriate `stages` property. For example a reasonable setting for a linter or code formatter would be `stages: [pre-commit, pre-merge-commit, pre-push, manual]`.